### PR TITLE
Fix/context issues

### DIFF
--- a/src/controllers/discoveryController.js
+++ b/src/controllers/discoveryController.js
@@ -29,7 +29,7 @@ export async function getDiscoveryMetadata(req, res) {
       "@type": "Datasetcatalogus",
       "Datasetcatalogus.titel": "Catalogus CoGhent",
       "Datasetcatalogus.beschrijving": "Catalogus van datasets voor de Collectie van de Gentenaar.",
-      "heeftDataset": []
+      "Datasetcatalogus.heeftDataset": []
     };
     const institutions = await db.models.Member.findAll(  {
       attributes: ['institution'],
@@ -58,7 +58,7 @@ export async function getDiscoveryMetadata(req, res) {
           institutionName = config[institutions[i].institution].institutionName;
           uitgevers = config[institutions[i].institution].institutionURI;
         }
-        md["heeftDataset"].push({
+        md["Datasetcatalogus.heeftDataset"].push({
           "@id": baseURI + 'dataset/' + institutions[i].institution + '/' +  md5(institutions[i].institution + databases[d].adlibDatabase),
           "@type": "Dataset",
           "Dataset.titel": databases[d].adlibDatabase + " van " + institutionName,

--- a/src/controllers/discoveryController.js
+++ b/src/controllers/discoveryController.js
@@ -26,9 +26,9 @@ export async function getDiscoveryMetadata(req, res) {
         "dcterms": "http://purl.org/dc/terms/"
       }],
       "@id": baseURI + 'dcat/coghent',
-      "@type": "DatasetCatalogus",
-      "DatasetCatalogus.titel": "Catalogus CoGhent",
-      "DatasetCatalogus.beschrijving": "Catalogus van datasets voor de Collectie van de Gentenaar.",
+      "@type": "Datasetcatalogus",
+      "Datasetcatalogus.titel": "Catalogus CoGhent",
+      "Datasetcatalogus.beschrijving": "Catalogus van datasets voor de Collectie van de Gentenaar.",
       "heeftDataset": []
     };
     const institutions = await db.models.Member.findAll(  {

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -19,13 +19,13 @@
           "@type": {
             "type": "string"
           },
-          "DatasetCatalogus.title": {
+          "Datasetcatalogus.title": {
             "type": "string"
           },
-          "DatasetCatalogus.beschrijving": {
+          "Datasetcatalogus.beschrijving": {
             "type": "string"
           },
-          "HeeftDataSet": {
+          "Datasetcatalogus.HeeftDataSet": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Dataset"


### PR DESCRIPTION
the catalogus json-ld page does not translate as expected to rdf. In the context link [Data Vlaanderen](https://data.vlaanderen.be/doc/applicatieprofiel/DCAT-AP-VL/standaard/2019-06-13/context/DCAT-AP-VL.jsonld) Datasetcatalogus is written in capitalized form while we use pascal case (DatasetCatalogus). 

Next to that, heeftDistributie needs to be prepended by `.Datasetcatalogus`. 

Swagger docs have been updated accordingly 