### PR TITLE
Update cultureel-erfgoed-object-ap.jsonld

### DIFF
--- a/src/public/context/cultureel-erfgoed-object-ap.jsonld
+++ b/src/public/context/cultureel-erfgoed-object-ap.jsonld
@@ -373,7 +373,7 @@
       "@id": "http://www.cidoc-crm.org/cidoc-crm/P102_has_title",
       "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
-    "MensgemaaktObject": "http://www.cidoc-crm.org/cidoc-crm/E22_Man-Made_Object",
+    "MensgemaaktObject": "http://www.cidoc-crm.org/cidoc-crm/E22_Human-Made_Object",
     "MensgemaaktObject.beeldtUit": {
       "@container": "@set",
       "@id": "http://www.cidoc-crm.org/cidoc-crm/P62_depicts",


### PR DESCRIPTION
Our data refers to "E22 Man-Made_Object" (http://www.cidoc-crm.org/cidoc-crm/E22_Man-Made_Object) but that has been deprecated in favour of "E22 Human-made_Object" (https://cidoc-crm.org/Entity/e22-human-made-object/version-7.1 ). The reason for that is obvious, words do matter.