### PR TITLE
Update cultureel-erfgoed-event-ap.jsonld

### DIFF
--- a/src/public/context/cultureel-erfgoed-event-ap.jsonld
+++ b/src/public/context/cultureel-erfgoed-event-ap.jsonld
@@ -249,7 +249,7 @@
     "Locatie": "http://www.w3.org/ns/prov#Location",
     "MaterieelDing": "http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing",
     "MensgemaaktKenmerk": "http://www.cidoc-crm.org/cidoc-crm/E25_Man-Made_Feature",
-    "MensgemaaktObject": "http://www.cidoc-crm.org/cidoc-crm/E22_Man-Made_Object",
+    "MensgemaaktObject": "http://www.cidoc-crm.org/cidoc-crm/E22_Human-Made_Object",
     "Meting": "http://www.cidoc-crm.org/cidoc-crm/E16_Measurement",
     "Meting.gemetenEntiteit": {
       "@id": "http://www.cidoc-crm.org/cidoc-crm/P39_measured",


### PR DESCRIPTION
Our data refers to "E22 Man-Made_Object" (http://www.cidoc-crm.org/cidoc-crm/E22_Man-Made_Object) but that has been deprecated in favour of "E22 Human-made_Object" (https://cidoc-crm.org/Entity/e22-human-made-object/version-7.1 ). The reason for that is obvious, words do matter.